### PR TITLE
SFR-958 Update requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,12 @@
 certifi==2019.6.16
 chardet==3.0.4
 Click==7.0
-Flask==1.1.1
+Flask==1.1.2
 gunicorn==19.9.0
 idna==2.8
 itsdangerous==1.1.0
-Jinja2==2.10.1
+Jinja2==2.11.2
 MarkupSafe==1.1.1
 requests==2.22.0
 urllib3==1.25.3
-Werkzeug==0.15.4
+Werkzeug==1.0.1


### PR DESCRIPTION
In running the flask app on python 3.8 I ran into a problem with `werkzeug==0.15.4`. Upgrading `Flask` to the latest version also bumped that version and resolved the problem. I'm not sure if this would occur on AWS but would like to bump it for future-proofing reasons.